### PR TITLE
Remove HUD method from docs

### DIFF
--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -722,25 +722,6 @@ Bottom-center notification in the kill feed area.
 | `ping` | No | Play notification sound (default: `true`) |
 | `steamId` | No | Target player's Steam ID. Omit to send to all players |
 
-### HUD notification
-
-Bottom-left overlay notification. Does not appear in chat — ideal for non-intrusive alerts.
-
-```json
-{
-  "method": "hud",
-  "text": "Quest complete!"
-}
-```
-
-| Field | Required | Description |
-|---|---|---|
-| `method` | Yes | `"hud"` |
-| `text` | Yes | Notification text |
-| `steamId` | No | Target player's Steam ID. Omit to send to all players |
-
----
-
 ### Per-player targeting
 
 Any method supports targeting a specific player by adding the `steamId` field:

--- a/docs/web-panel.md
+++ b/docs/web-panel.md
@@ -124,7 +124,6 @@ Real-time chat viewer showing all in-game chat messages. Requires `LogWatcherEna
 | Chat | Standard in-game chat message. Choose a color from the color picker (Yellow, White, Cyan, Green, Red) |
 | Warning | Center-screen notification. Choose a custom color from the color picker and set display duration in seconds |
 | Kill Feed | Bottom-center notification with prefix, name, and suffix fields. Toggle the sound on or off |
-| HUD | Bottom-left overlay notification. Does not appear in chat — ideal for non-intrusive alerts |
 
 ![Chat Tab](assets/images/panel/panel-chat.jpg)
 


### PR DESCRIPTION
## Summary
- Removed HUD notification section from HTTP API docs (method was removed from the API — equivalent to white chat)
- Removed HUD row from web panel Chat tab docs (dropdown no longer offers it)

Closes #45