### PR TITLE
Docs catch-up: v0.12.2 -> v0.13.3

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6,11 +6,11 @@ The leading `#` is optional for ggCON-specific commands but is required for nati
 
 ## How commands are executed
 
-Native SCUM admin commands require at least one player to be online — ggCON runs each command through whichever player is currently available on the server. No dedicated admin account is required; any online player will do, though you can restrict or prefer specific players using the [executor selection settings](config-reference.md#executor-selection).
+Native SCUM admin commands require at least one player to be online — ggCON runs each command through whichever player is currently available on the server. No dedicated admin account is required; any online player will do, though you can restrict or prefer specific players using the [executor selection settings](config-reference.md#restricttoadmins).
 
 This has three important implications:
 
-**Commands appear in SCUM's admin log under that player's name.** Depending on your [executor selection settings](config-reference.md#executor-selection), this may be a specific player you've configured or simply whoever happens to be online.
+**Commands appear in SCUM's admin log under that player's name.** Depending on your [executor selection settings](config-reference.md#restricttoadmins), this may be a specific player you've configured or simply whoever happens to be online.
 
 **Context-sensitive commands act on the executing player if no target is specified.** For example:
 
@@ -29,7 +29,7 @@ This applies to any command that accepts an optional player argument. When in do
 **The player being used will see the command output in their in-game chat.** Any `#ListPlayers` result, economy query, or automated command output will appear on that player's screen. Enable [`SuppressCommandOutput`](config-reference.md#suppresscommandoutput) to prevent this — it is recommended for most setups.
 
 !!! tip "Restrict the executor"
-    Use `RestrictToAdmins` and `PreferredSteamIDs` in the panel's **Settings** tab to control which player's account commands run under. See [Executor selection](config-reference.md#executor-selection).
+    Use `RestrictToAdmins` and `PreferredSteamIDs` in the panel's **Settings** tab to control which player's account commands run under. See [Executor selection](config-reference.md#restricttoadmins).
 
 ---
 
@@ -167,6 +167,7 @@ Sends a message to all players currently on the server.
 #Broadcast Cyan Global-style message
 #Broadcast Green Squad-style message
 #Broadcast Red Something went wrong!
+#Broadcast Orange Attention-grabbing notice
 #Broadcast ServerMessage Also yellow (semantic alias)
 #Broadcast Error Also red (semantic alias)
 ```
@@ -246,7 +247,7 @@ The target player must be online. If they are not, the command is rejected:
 ```
 
 !!! note
-    `#ExecAs` overrides [executor selection settings](config-reference.md#executor-selection) for the duration of that single command. The target player temporarily becomes the executor, so any command that acts on "the running player" will act on them.
+    `#ExecAs` overrides [executor selection settings](config-reference.md#restricttoadmins) for the duration of that single command. The target player temporarily becomes the executor, so any command that acts on "the running player" will act on them.
 
 !!! tip "No admin status required"
     The target player does not need to be an admin or have any elevated permissions. ggCON handles command dispatch internally, bypassing the normal in-game permission checks. Any online player can be used as the executor.
@@ -290,7 +291,7 @@ The `#SetAttributes` command has no Steam ID parameter — it acts on the player
 Spawns an item for a specific player. The item appears near the player's location.
 
 ```
-#GiveItem <steamId> <itemName> [quantity]
+#GiveItem <steamId> <itemName> [quantity] [StackCount <stack>]
 ```
 
 | Parameter | Required | Description |
@@ -298,6 +299,7 @@ Spawns an item for a specific player. The item appears near the player's locatio
 | `steamId` | Yes | The target player's 64-bit Steam ID |
 | `itemName` | Yes | The item class name (e.g., `Backpack_Tactical_01`, `Knife_Hunting`) |
 | `quantity` | No | Number of items to spawn (default: 1) |
+| `StackCount <stack>` | No | Stack size per item — use for ammo, cash, and other stackable items so the player gets one stack instead of `quantity` separate piles |
 
 **Examples:**
 
@@ -305,7 +307,11 @@ Spawns an item for a specific player. The item appears near the player's locatio
 #GiveItem 76561198031234567 Backpack_Tactical_01 1
 #GiveItem 76561198031234567 Knife_Hunting 3
 #GiveItem 76561198031234567 Ammo_Rifle_556x45_30rnd
+#GiveItem 76561198031234567 Magazine_AK15 3 StackCount 30
 ```
+
+!!! tip "Stack count"
+    SCUM's native keyword form (`StackCount 30`) and the positional form (`... 3 30`) both work. To give 10,000 cash, use quantity 1 with `StackCount 10000` rather than quantity 10000.
 
 **Response:**
 
@@ -585,4 +591,4 @@ If `LimitAdminCommands = true` is set in your config, only commands listed in `g
 }
 ```
 
-See the [Config Reference](config-reference.md#command-filtering) for details.
+See the [Config Reference](config-reference.md#limitadmincommands) for details.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -190,10 +190,24 @@ This is recommended for most setups to avoid unexpected output appearing for whi
 
 ---
 
+### SuppressSpawnedReplies
+**Type:** bool &nbsp;|&nbsp; **Default:** `false`
+
+When ggCON spawns items for a player (from the panel, the API, or a plugin), the player used to deliver them normally sees `Spawned X.` confirmations in their in-game chat. Set to `true` to suppress those confirmations. The asset-loading chatter (`Loading X…`) is always suppressed for ggCON-dispatched items regardless of this setting. Commands an admin types in-game manually are unaffected.
+
+---
+
+### UnlockDeveloperCommands
+**Type:** bool &nbsp;|&nbsp; **Default:** `false`
+
+When `true`, unlocks hidden developer-only commands (such as `#UpgradeBaseBuildingElementsWithinRadius`) so admins can use them in-game — no separate Lua mod required. Leave off unless you specifically need them.
+
+---
+
 ### SlashResponseColor
 **Type:** string &nbsp;|&nbsp; **Default:** `yellow`
 
-Color used for slash command responses sent back to the player in chat. Valid values: `yellow`, `white`, `cyan`, `green`, `red`.
+Color used for slash command responses sent back to the player in chat. Valid values: `yellow`, `white`, `cyan`, `green`, `red`, `orange`.
 
 ---
 
@@ -201,6 +215,55 @@ Color used for slash command responses sent back to the player in chat. Valid va
 **Type:** string &nbsp;|&nbsp; **Default:** *(empty)*
 
 Optional prefix prepended to slash command responses in chat, e.g. `[SERVER]`.
+
+---
+
+### AdminDisplayName
+**Type:** string &nbsp;|&nbsp; **Default:** `ADMIN`
+
+The name substituted for the `{name}` placeholder in the admin chat prefix templates below.
+
+---
+
+### AdminChatBroadcastTemplate
+**Type:** string &nbsp;|&nbsp; **Default:** `[ADMIN] {message}`
+
+Template applied to broadcasts sent from the panel's **Send Message** feature, so players can tell an admin is talking. Placeholders: `{name}` (the `AdminDisplayName`) and `{message}` (the text you typed). Clear it to send broadcasts with no prefix. Plugin-dispatched chat and slash command responses are unaffected.
+
+---
+
+### AdminChatWhisperTemplate
+**Type:** string &nbsp;|&nbsp; **Default:** `[WHISPER from {name}] {message}`
+
+Template applied to private (per-player) messages sent from the panel. Placeholders: `{name}`, `{message}`, and `{playerName}` (the recipient's name). Clear it to send whispers with no prefix.
+
+---
+
+### UnstuckDistanceMeters
+**Type:** integer (meters) &nbsp;|&nbsp; **Default:** `100`
+
+How far a player is moved when they use the [`/unstuck`](slash-commands.md#unstuck) slash command.
+
+---
+
+### UnstuckCooldownHours
+**Type:** integer (hours) &nbsp;|&nbsp; **Default:** `5`
+
+How long a player must wait between `/unstuck` uses. Set to `0` to disable the cooldown.
+
+---
+
+### UnstuckRequiresApproval
+**Type:** bool &nbsp;|&nbsp; **Default:** `false`
+
+When `true`, `/unstuck` requests are queued for an admin to approve or deny from the panel header instead of teleporting the player immediately.
+
+---
+
+### DiscordUnstuckWebhook
+**Type:** string &nbsp;|&nbsp; **Default:** *(empty)*
+
+Discord webhook URL that receives an alert whenever a new `/unstuck` request is queued for approval (used only when `UnstuckRequiresApproval = true`). Leave empty to disable.
 
 ---
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,129 @@
+# Features
+
+**ggCON turns a SCUM dedicated server into something you run from a browser.** A full admin panel, a live map, an in-game economy, kill tracking, player services, and an HTTP/RCON API to automate all of it — built and maintained by [GG Host](https://www.gghost.games), the official host of SCUM.
+
+No desktop tools, no manual database edits, no fragile scripts. Install it, set a password, and run your server from anywhere.
+
+<div class="grid cards" markdown>
+
+-   🖥️ __Web Admin Panel__
+
+    ---
+
+    Manage your whole server from the browser — players, console, chat, vehicles, squads, flags, and live status. Real-time updates, no page refresh needed.
+
+    [Explore the panel →](web-panel.md)
+
+-   🗺️ __Live Island Map__
+
+    ---
+
+    Watch players, vehicles, drones, and bases move in real time on a high-resolution tiled map. Measure distances, copy coordinates, and teleport with a click.
+
+    [See the map →](web-panel.md#map)
+
+-   👤 __Deep Player Management__
+
+    ---
+
+    Health, skills, attributes, gear, economy, body effects, and location for every player. Teleport, kick, ban, and adjust fame/cash/gold right from the player card.
+
+    [Player tools →](web-panel.md#players)
+
+-   🎒 __Spawn Anything__
+
+    ---
+
+    Give any of 6,000+ items, all 19 vehicle types, or spawn zombies, animals, and armed NPCs near a player — straight from the panel with searchable pickers.
+
+    [Spawning →](web-panel.md#give-item)
+
+-   🛒 __In-Game Economy__
+
+    ---
+
+    The Quarter Master plugin adds a web storefront, item and vehicle packages priced in Rations or Cash, stock and discounts, cross-server GG Coins, and PvP/NPC kill rewards.
+
+    [Quarter Master →](plugins.md#quarter-master)
+
+-   ⚔️ __Kill Feed & Leaderboards__
+
+    ---
+
+    A real-time feed of PvP, NPC, trap, and suicide kills with weapon icons and a map. Player leaderboards, in-game chat broadcasts, and per-type Discord webhooks.
+
+    [Kill Feed →](plugins.md#kill-feed)
+
+-   🎯 __NPC Tracking__
+
+    ---
+
+    Live status, health, and map positions for guards, drifters, zombies, animals, sentries, drones, and Razor — and it feeds the Kill Feed and kill rewards.
+
+    [NPC Tracker →](plugins.md#npc-tracker)
+
+-   🚕 __Player Services__
+
+    ---
+
+    A paid taxi service, a `/unstuck` self-rescue command, claimable loot-drop packs, and custom slash commands you define — all from in-game chat.
+
+    [Slash commands →](slash-commands.md)
+
+-   📊 __Server Analytics__
+
+    ---
+
+    Track FPS, frame time, and entity counts over time with interactive charts, so you can see exactly how your server performs and when.
+
+    [Analytics →](plugins.md#log-analyzer)
+
+-   🔌 __Plugin Marketplace__
+
+    ---
+
+    Browse, install, update, and remove plugins from inside the panel — no file management. The feature set grows without ever touching the core.
+
+    [Plugins →](plugins.md)
+
+-   🔗 __HTTP API & RCON__
+
+    ---
+
+    Automate everything ggCON can do from your own tools, bots, and scripts through a clean JSON HTTP API and a standard RCON server.
+
+    [HTTP API →](http-api.md)
+
+-   🔄 __One-Click Updates__
+
+    ---
+
+    The panel checks for new versions and stages them for the next restart. Critical updates stage themselves automatically — no babysitting required.
+
+    [Auto-Update →](auto-update.md)
+
+-   🔒 __Secure by Design__
+
+    ---
+
+    IP allowlists, password authentication, brute-force rate limiting, and HTTPS access through GG Host's built-in SSL proxy.
+
+    [Panel access →](web-panel.md#accessing-the-panel)
+
+-   🌍 __Speaks Your Language__
+
+    ---
+
+    The web panel and the player storefront are available in English, Chinese, Thai, Russian, German, and Ukrainian.
+
+    [Get started →](getting-started.md)
+
+</div>
+
+## Built by GG Host
+
+[![GG Host](assets/images/logo.png)](https://www.gghost.games)
+
+ggCON is built and maintained by [GG Host](https://www.gghost.games) — the official host of the SCUM dedicated servers, trusted by the SCUM development team and the community. The same team behind purpose-built hardware, in-house DDoS protection, and minutes-not-hours support brings that same depth to server administration.
+
+[Get a SCUM server from GG Host →](https://www.gghost.games/store/scum-server)

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -42,8 +42,8 @@ Returns the mod's running status. **No authentication required.**
 {
   "ok": true,
   "mod": "ggCON",
-  "version": "0.12.2",
-  "build": "2026-04-04 10:15:00",
+  "version": "0.13.3",
+  "build": "2026-05-28 10:22:24",
   "service": "http",
   "running": true
 }
@@ -89,6 +89,9 @@ Returns the current player list. Auth required.
       "characterName": "John Smith",
       "steamName": "jsmith99",
       "userId": "76561198000000001",
+      "profileId": 8,
+      "realName": "John Smith",
+      "fakeName": "Shadow",
       "fame": 1500,
       "accountBalance": 2500,
       "goldBalance": 10,
@@ -132,6 +135,9 @@ Returns the current player list. Auth required.
 | `characterName` | string | SCUM in-game character name |
 | `steamName` | string | Steam display name |
 | `userId` | string | Steam ID (64-bit) |
+| `profileId` | number | SCUM internal user profile ID (`0` if not matched in the database) |
+| `realName` | string | Character's real in-game name from the database |
+| `fakeName` | string | Character's alias / fake name if set, otherwise empty |
 | `fame` | number \| null | Fame points |
 | `accountBalance` | number \| null | In-game currency balance |
 | `goldBalance` | number \| null | Gold balance |
@@ -249,8 +255,8 @@ Returns server state. Auth required.
 {
   "ok": true,
   "online": true,
-  "modVersion": "0.12.2",
-  "modBuild": "2026-04-03 14:30:00",
+  "modVersion": "0.13.3",
+  "modBuild": "2026-05-28 10:22:24",
   "scumVersion": "1.2.2.1.108938+0",
   "onlinePlayers": 12,
   "timeOfDay": 14.5,
@@ -750,6 +756,43 @@ Returns the admin command reference, built from the game engine at startup. Auth
 
 ---
 
+## GET /slash-commands.json
+
+Returns all registered slash commands, grouped by source. Auth required.
+
+This is the same data shown by the in-game `/help` command. See [Slash Commands](slash-commands.md) for details.
+
+**Response**
+
+```json
+{
+  "ok": true,
+  "groups": [
+    {
+      "plugin": "core",
+      "commands": [
+        { "command": "/help", "description": "Show available commands" },
+        { "command": "/unstuck", "description": "Free yourself when stuck" }
+      ]
+    },
+    {
+      "plugin": "loot-drops",
+      "commands": [
+        { "command": "/starter", "description": "Claim the Starter Kit" }
+      ]
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `groups[].plugin` | string | Source of the commands: `core` for built-ins, or a plugin's ID for plugin commands |
+| `groups[].commands[].command` | string | The slash command, including the leading `/` |
+| `groups[].commands[].description` | string | Human-readable description shown in `/help` |
+
+---
+
 ## POST /spawn
 
 Spawns item(s) for a player. Auth required.
@@ -992,25 +1035,6 @@ Bottom-center notification in the kill feed area.
 | `ping` | No | Play notification sound (default: `true`) |
 | `steamId` | No | Target player's Steam ID. Omit to send to all players |
 
-### HUD notification
-
-Bottom-left overlay notification. Does not appear in chat — ideal for non-intrusive alerts.
-
-```json
-{
-  "method": "hud",
-  "text": "Quest complete!"
-}
-```
-
-| Field | Required | Description |
-|---|---|---|
-| `method` | Yes | `"hud"` |
-| `text` | Yes | Notification text |
-| `steamId` | No | Target player's Steam ID. Omit to send to all players |
-
----
-
 ### Per-player targeting
 
 Any method supports targeting a specific player by adding the `steamId` field:
@@ -1050,6 +1074,7 @@ The `type` field controls the color of the message in-game. Values are case-inse
 | `Green` | Green | |
 | `Red` | Red | Same as `Error` |
 | `Error` | Red | Alias for `Red` |
+| `Orange` | Orange | Bright attention color (matches SCUM's MOTD highlight) |
 
 Unknown values fall back to `Yellow`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,15 +13,19 @@
 - **Vehicle Spawning** — give any of the 19 vehicle types directly to a player from the panel
 - **Entity Spawning** — spawn zombies, animals, armed NPCs, Brenner, and Razor near any player with a tabbed picker
 - **Multi-language** — web panel available in English, Chinese, Thai, Russian, German, and Ukrainian
+- **In-game Economy** — the Quarter Master plugin adds a web storefront, a package shop priced in Rations or Cash, cross-server GG Coins, stock and discounts, and PvP/NPC kill rewards
+- **Kill Feed & Leaderboards** — real-time PvP, NPC, trap, and suicide kill feed with a player leaderboard, in-game chat broadcasts, and Discord webhooks
+- **NPC Tracking** — live status, health, and map positions for guards, drifters, zombies, animals, sentries, drones, and Razor
+- **Paid Teleport (Taxi)** — players pay in-game cash to travel to admin-set destinations, with a PvP-safe countdown
 - **AI NPCs** *(coming soon)* — AI-powered characters that interact with players in chat and execute admin commands
-- **Slash Commands** — players type `/help`, `/starter`, etc. in chat for instant responses; plugins can register custom commands
-- **Plugin System** — extend ggCON with plugins for loot drops, analytics, NPCs, dev tools, and more — with a built-in marketplace
+- **Slash Commands** — players type `/help`, `/unstuck`, `/shop`, `/taxi`, and more in chat for instant responses; admins and plugins can register custom commands
+- **Plugin System** — extend ggCON with plugins for the in-game shop, kill feed, loot drops, NPC tracking, paid taxi, analytics, and more — with a built-in marketplace
 - **Auto-Update** — check for and stage updates directly from the panel, applied on next server restart
 - **SSL Access** — access the panel securely over HTTPS via GG Host's built-in SSL proxy
 - **Server Controls** — set time of day and weather directly from the panel
 - Run admin commands and capture their output via HTTP or RCON
 - Execute developer commands without any database modifications
-- Send in-game messages, warnings, HUD overlays, and kill feed notifications to all players or a specific player
+- Send in-game chat messages, center-screen warnings, kill feed notifications, and HUD overlays to all players or a specific player
 - Monitor server logs in real-time (chat, kills, economy, admin, and more)
 - Secure access with IP allowlists, password authentication, and rate limiting
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@
 
 | I want to… | Go to |
 |---|---|
+| See everything ggCON can do | [Features](features.md) |
 | Install and configure the mod | [Getting Started](getting-started.md) |
 | Use the web panel | [Web Panel](web-panel.md) |
 | Set up AI NPCs | [NPC System](npc-system.md) |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -26,6 +26,8 @@ Plugins can declare a minimum ggCON version in their metadata. If your installed
 Configurable item drop packs with slash commands, per-player allowlists, and claim limits.
 
 - **Drop packs** — create bundles of items that players can claim with a slash command (e.g. `/starter`, `/event-drop`)
+- **Vehicles in packs** — packs can include assembled vehicles alongside items; click **+ Vehicle** in the pack editor to pick from the live vehicle catalog. Vehicle rows show a 🚗 icon and a **VEHICLE** badge. A quantity above 1 spawns that many separate vehicles
+- **Stack count** — each item has a stack-size field next to quantity. Use it for ammo, cash, and other stackable items so players receive one stack instead of many separate piles
 - **Per-player limits** — set how many times each player can claim a pack (e.g. once per wipe)
 - **Allowlists** — optionally restrict packs to specific Steam IDs
 - **Expiry dates** — set an expiry time after which the pack is no longer claimable
@@ -56,16 +58,37 @@ Server performance analytics — replaces the standalone ServerLogAnalyzer deskt
 
 ### Kill Feed
 
-Real-time kill event feed for PvP, NPC, trap, and suicide kills.
+Real-time kill event feed for PvP, NPC, trap, and suicide kills, with history, Discord integration, in-game broadcasts, and a leaderboard.
 
 - **Kill list** — scrollable feed showing killer, victim, weapon, distance, and kill type (PvP, NPC, Trap, Suicide)
 - **Weapon icons** — dynamic icon lookup from the item catalog with a manual fallback table for common weapons
 - **Detail strip** — expanded view of the selected kill event with full player info
 - **Interactive map** — shows killer and victim positions with markers
 - **LIVE / PAUSED mode** — auto-follow new events in LIVE mode, or freeze the list to inspect past events
-- **Session clear** — kill history resets automatically when the server restarts
+- **History** — review past events with a time-window dropdown (Current Session / 24h / 48h / All)
+- **Multi-select type filters** — toggle PvP / NPC / Trap / Suicide independently (e.g. show PvP + Trap, hide NPC); the **All** chip resets to everything. Your choice is remembered across reloads
+- **NPC kills** — player-vs-NPC kills appear in the feed when the [NPC Tracker](#npc-tracker) plugin is installed, with weapon icons and map markers
 
-**Requires:** ggCON v0.11.6+
+**Discord webhooks**
+
+- Post kills to a Discord channel with weapon icons and full kill detail
+- **Per-type webhooks** — route PvP / NPC / Trap / Suicide to separate channels (each falls back to a default URL if left blank), so a PvP-monitoring channel isn't flooded with NPC kills
+- **PvP delay** — optionally hold player-kill posts for a configurable number of minutes (for OPSEC during competitive events); the delay queue survives a server restart
+- **Map snapshot** — optionally include a map image of where the kill happened in the public embed
+
+**In-game chat broadcasts**
+
+- Announce kills in in-game chat, configured per type (PvP / NPC / Trap / Suicide)
+- Editable templates with placeholders `{killer}`, `{victim}`, `{weapon}`, `{distance}`, and `{category}`, plus a color picker
+- All types disabled by default — opt in per type
+
+**Leaderboard**
+
+- **Leaderboard sub-tab** — rank players by PvP kills, PvP deaths, K/D ratio, NPC kills, trap kills, suicides, longest shot, and favorite weapon. Filter by time window (Current Session / 24h / 7 days / 30 days / All); top 3 get gold/silver/bronze medals
+- **`/leaderboard` slash command** (alias `/top`) — players see a quick top-10 in chat; optional window argument (`24h` / `7d` / `30d` / `all`)
+- **Scheduled Discord leaderboard** — post a leaderboard to Discord on a schedule (Manual / Daily / Weekly, day-of-week, UTC time, window, and top-N)
+
+**Requires:** ggCON v0.11.6+ (NPC kills require the NPC Tracker plugin)
 
 ---
 
@@ -83,6 +106,20 @@ Real-time trap event feed showing crafting, arming, disarming, and triggering of
 
 ---
 
+### NPC Tracker
+
+Real-time tracking of every AI character on your server — guards, drifters, zombies, animals, sentries, drones, and Razor.
+
+- **Tracked types** — guards, drifters, zombies, animals, sentries, drones, and Razor, each shown with its own category color
+- **Live status** — health bars and alive/dead status, updated continuously
+- **Kill log** — records NPC kills, including the weapon used
+- **Map markers** — NPC positions shown on the live map
+- **Feeds other plugins** — NPC kills flow into the [Kill Feed](#kill-feed), and [Quarter Master](#quarter-master) can award rations per NPC type (see Kill rewards below)
+
+**Requires:** ggCON v0.12.9+
+
+---
+
 ### Quarter Master
 
 A complete in-game economy and player reward system with a web storefront — give your players something to work toward.
@@ -94,12 +131,24 @@ Admins build item packages and set prices in Rations, in-game Cash, or both. Pla
 The Quarter Master tab in the web panel is where you create and manage everything:
 
 - **Packages** — bundle any combination of items into purchasable packages; set a name, description, and price in Rations, Cash, or both
-- **Categories** — organize packages into custom categories (e.g., Weapons, Supplies, Gear); categories appear as filter pills in the storefront
+- **Stack count** — each item in a package has a stack-size field, so a single package slot can deliver a full stack (ammo, cash, etc.) instead of many separate piles
+- **Categories** — organize packages into custom categories (e.g., Weapons, Supplies, Gear); categories appear as filter pills in the storefront. Each category has an enable toggle to hide its packages without deleting them
 - **Discounts** — set a percentage discount on any package with an optional expiry date; storefront shows the original price crossed out with a "X% OFF" badge
 - **Stock limits** — cap how many times a package can be purchased; storefront shows "3 left" or "Sold Out" automatically
 - **Vehicle packages** — sell vehicles through the shop; a permanent "Vehicles" category is auto-populated from the game engine's 19 vehicle types; enable individual vehicles and set prices
+- **Bundle thumbnails** — multi-item packages automatically show a representative item icon (you can pick which item is the "lead") and a **Bundle** badge in the storefront
+- **Export / import packages** — back up your shop or share package templates as a JSON file; import matches categories by name so templates are portable across servers, with auto-rename for conflicts and an import preview
+- **Open / close controls** — open or close the shop (new purchases) and deliveries (stash claims) independently; use them to freeze the shop during events without touching anyone's balances or stash
 - **Example presets** — new installs come with 3 example categories and 5 sample packages to get started quickly
-- **Economy overview** — Player Lookup tool in the Economy tab for reviewing transaction history, stash contents, and resolving disputes
+- **Economy overview** — a sales summary (totals, sales by category, top packages) plus a Player Lookup tool for reviewing transaction history, stash contents, and resolving disputes
+- **Grant Rations to All** — bulk-grant rations to every online player in one click, optionally including offline players who have used the shop before
+
+**Kill rewards**
+
+- Award Rations for **PvP kills** and **NPC kills**, with separate amounts per NPC category (Guard, Drifter, Zombie, Animal, Sentry, Drone)
+- **Per-class overrides** — set a custom reward for a specific NPC type (e.g. Razor) that wins over the category default
+- **Squad-kill penalty** — optionally replace the PvP reward with a deduction when killer and victim are in the same squad, to discourage friendly fire (suicides are exempt)
+- NPC kill rewards require the [NPC Tracker](#npc-tracker) plugin
 
 #### Player Storefront
 
@@ -109,6 +158,7 @@ Players access their server's storefront at `shop.gghost.games`, log in with the
 - **Purchase flow** — select a package, confirm the price, items are added to the player's stash
 - **Offline purchasing** — players can buy packages even when not connected to the server; Ration deductions happen immediately, Cash deductions are queued for next login
 - **Stash** — purchased items are grouped by package in a persistent stash; players click "Claim All" in the storefront when in-game to receive their items
+- **Delivery zones** — optionally require players to stand in an admin-configured zone (shop counter, safe room, event point) to claim their stash; configure one or more zones in QM Settings
 - **Bank Statement** — full purchase history with timestamps
 - **Multi-language** — storefront available in English, Chinese, Thai, Russian, German, and Ukrainian; language picker on login and in the header
 
@@ -117,6 +167,7 @@ Players access their server's storefront at `shop.gghost.games`, log in with the
 A global currency earned through playtime across all GG Host servers. The earn rate is the same globally, with special events offering multipliers (e.g. 2x weekend).
 
 - **Earn by playing** — players automatically earn GG Coins based on time spent online; the rate is the same across all servers
+- **Earn notifications** — optionally show players an in-game notification each time they earn GG Coins from playtime
 - **Cross-server wallet** — GG Coins are stored in a global wallet, not tied to a single server; players who play on multiple GG Host servers accumulate coins across all of them
 - **Withdraw to Rations** — players can convert GG Coins into Rations at an admin-configured exchange rate via the storefront
 - **Balance display** — current GG Coin balance shown in the storefront header with a withdraw button
@@ -137,6 +188,22 @@ The `shop.gghost.games` landing page lists all servers running Quarter Master. E
 **Slash command:** Players type `/shop` in-game to receive their personal storefront URL with login PIN.
 
 **Requires:** ggCON v0.12.0+
+
+---
+
+### Taxi Service
+
+A paid teleport service — players spend in-game cash to travel to admin-configured destinations.
+
+- **`/taxi`** — lists available destinations and their fares; `/taxi <name>` books a ride; `/taxi cancel` aborts a pending ride and refunds the fare
+- **Destinations** — configure named locations (X/Y/Z) and a fare each, in the Taxi tab
+- **Anti-escape countdown** — a configurable delay runs before the teleport (default 120 seconds; 0–600). The ride **cancels and refunds automatically if the player takes damage, dies, or logs out** — so the taxi can't be used to escape a PvP fight
+- **Per-player cooldown** — a configurable wait between rides (default 5 minutes)
+- **Settings** — enable/disable, countdown seconds, cooldown minutes, and a default fare
+
+Available in the plugin marketplace — install it when you're ready to offer paid teleports.
+
+**Requires:** ggCON v0.13.0+
 
 ---
 

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -17,6 +17,7 @@ Displays all available slash commands, grouped by source.
 ```
 ggCON Commands:
   /help — Show available commands
+  /unstuck — Free yourself when stuck
 
 Loot Drops:
   /starter — Claim the Starter Kit
@@ -24,6 +25,25 @@ Loot Drops:
 ```
 
 Commands from plugins are grouped under the plugin name so you can quickly find what's available.
+
+---
+
+### /unstuck
+
+Frees a player who is stuck in terrain, fallen through the world, or otherwise unable to move, by teleporting them a short distance in a random horizontal direction.
+
+```
+/unstuck
+```
+
+Admin-configurable in **Settings → General**:
+
+- **Distance** — how far the player is moved (default 100 m)
+- **Cooldown** — how long a player must wait between uses (default 5 hours; set to 0 to disable the cooldown)
+- **Require admin approval** — when enabled, `/unstuck` queues the request for an admin to review instead of teleporting immediately. Admins see pending requests via a bell icon in the panel header and can approve or deny each one
+- **Discord webhook** — optionally post an alert to Discord whenever a new `/unstuck` request is queued for approval
+
+Dead players can't use `/unstuck` — they're asked to respawn first.
 
 ---
 
@@ -35,43 +55,66 @@ Commands from plugins are grouped under the plugin name so you can quickly find 
 
 ### Cooldown
 
-All slash commands share a **5-second per-player cooldown** to prevent accidental double-triggers and spam. If a player sends a command during cooldown, it is silently ignored.
+Most slash commands share a **5-second per-player cooldown** to prevent accidental double-triggers and spam. If a player sends a command during cooldown, it is silently ignored. (Some commands set their own longer cooldown — for example `/unstuck`.)
 
 ---
 
 ## Plugin Slash Commands
 
-Plugins can register their own slash commands. For example, the [Loot Drops](plugins.md#loot-drops) plugin registers a command for each configured drop pack:
+Plugins can register their own slash commands. Examples from the built-in plugins:
+
+[Loot Drops](plugins.md#loot-drops) registers a command for each configured drop pack:
 
 - `/starter` — claim the "Starter Kit" pack
 - `/event-drop` — claim the "Event Drop" pack
 
-The command name is configurable per pack. See each plugin's documentation for details on its commands.
+The command name is configurable per pack.
 
-The [Quarter Master](plugins.md#quarter-master) plugin registers:
+[Quarter Master](plugins.md#quarter-master) registers:
 
 - `/shop` — sends the player their personal storefront URL with a one-time login PIN
+
+[Kill Feed](plugins.md#kill-feed) registers:
+
+- `/leaderboard` (alias `/top`) — shows a top-10 leaderboard in chat; optional window argument (`24h` / `7d` / `30d` / `all`)
+
+[Taxi Service](plugins.md#taxi-service) registers:
+
+- `/taxi` — lists destinations and fares; `/taxi <name>` books a ride; `/taxi cancel` cancels a pending ride and refunds the fare
+
+See each plugin's documentation for details on its commands.
 
 ---
 
 ## Custom Slash Commands
 
-Admins can create their own slash commands with predefined responses — no plugin required. Go to **Settings > Slash Commands** in the web panel to add commands like `/discord`, `/rules`, or `/website`.
+Admins can create their own slash commands with predefined responses — no plugin required. Go to **Settings → Slash Commands** in the web panel to add commands like `/discord`, `/rules`, or `/website`.
 
 For each custom command, you configure:
 
 - **Command name** — the word after `/` (e.g., `discord`)
 - **Response text** — the message sent back to the player
-- **Color** — the chat color of the response (Yellow, White, Cyan, Green, Red)
+- **Color** — the chat color of the response (Yellow, White, Cyan, Green, Red, Orange)
 - **Prefix** — optional text prepended to the response (e.g., `[INFO]`)
+
+The response text supports two placeholders that are filled in when the command runs:
+
+- `{playerName}` — the name of the player who ran the command
+- `{steamId}` — that player's Steam ID
 
 Custom commands are registered at startup and when settings are saved. They appear in `/help` output alongside built-in and plugin commands.
 
-!!! note
-    Custom command names cannot conflict with built-in or plugin commands. If a collision is detected, the custom command is rejected.
+!!! note "Overriding built-in commands"
+    A custom command may reuse the name of a built-in or plugin command (for example `help`) to replace its response — useful for translating or rewording built-in replies. Removing the custom command restores the original. Two custom commands cannot share the same name.
+
+---
+
+## Listing registered commands
+
+The [`GET /slash-commands.json`](http-api.md#get-slash-commandsjson) endpoint returns every registered slash command grouped by source (core, custom, and each plugin) — the same data shown in `/help`.
 
 ---
 
 ## Requirements
 
-Slash commands work automatically — no additional configuration is needed. They are detected directly from the game engine, so `LogWatcherEnabled` is **not** required for slash commands to function (though it is still needed for the Chat and Logs tabs in the panel).
+Slash commands work automatically — no additional configuration is needed. They are detected directly from the game engine, so the Log Watcher is **not** required for slash commands to function (though it is still needed for the Chat and Logs tabs in the panel).

--- a/docs/web-panel.md
+++ b/docs/web-panel.md
@@ -73,13 +73,18 @@ The default landing page. Shows server information and live controls:
 
 Lists all online players with sortable columns. Use the **"Online / All Players"** toggle to switch between online-only and a full search of every player who has ever connected (including offline players).
 
-The "All Players" mode queries the server database and supports search by name or Steam ID. Offline player cards show last login/logout, economy data, and a "Show on Map" button for their last known position.
+The "All Players" mode queries the server database and supports search by name or Steam ID. Offline player cards show last login/logout, economy data, and a "Show on Map" button for their last known position. The All Players list also shows Account ID and Fake IGN columns.
+
+The filter box matches against the character name, Steam ID, Account ID, Real IGN, and Fake IGN, so you can search by any of them.
 
 | Column | Description |
 |---|---|
 | Name | SCUM in-game character name |
 | Steam | Steam profile name |
 | Steam ID | 64-bit Steam ID (clickable — opens Steam profile) |
+| Account ID | SCUM's internal user profile ID |
+| Real IGN | Character's real in-game name from the database |
+| Fake IGN | Character's alias, if set |
 | Fame | Fame points |
 | Ping | Network latency |
 | Flags | Admin, God Mode, Immortal, Dead, Drone badges |
@@ -111,7 +116,7 @@ Click a player in the list or on the map to see full details:
 - **Give Vehicle** — opens a vehicle picker to spawn any of the 19 vehicle types directly to the player (see [Give Vehicle](#give-vehicle))
 - **Spawn Entities** — opens a tabbed picker to spawn zombies, animals, armed NPCs, Brenner, or Razor near the player (see [Spawn Entities](#spawn-entities))
 - **Show on Map** — switches to the Map tab and flies to the player's location
-- **Teleport To...** — opens the map in teleport mode (see [Teleport from Map](#teleport-from-map))
+- **Teleport To...** — choose a destination by pasting coordinates, picking a saved location, or clicking the map, with an optional facing direction (see [Teleport a player](#teleport-a-player))
 - **Kick** — kicks the player from the server (with confirmation dialog)
 - **Ban** — bans the player from the server (with confirmation dialog)
 
@@ -168,10 +173,9 @@ Real-time chat viewer showing all in-game chat messages.
 
 | Method | Description |
 |---|---|
-| Chat | Standard in-game chat message. Choose a color from the color picker (Yellow, White, Cyan, Green, Red) |
+| Chat | Standard in-game chat message. Choose a color from the color picker (Yellow, White, Cyan, Green, Red, Orange) |
 | Warning | Center-screen notification. Choose a custom color from the color picker and set display duration in seconds |
 | Kill Feed | Bottom-center notification with prefix, name, and suffix fields. Toggle the sound on or off |
-| HUD | Bottom-left overlay notification. Does not appear in chat — ideal for non-intrusive alerts |
 
 ![Chat Tab](assets/images/panel/panel-chat.jpg)
 
@@ -305,11 +309,23 @@ Loaded plugins that provide a panel tab appear in the sidebar under the "Plugins
 
 Click the **Settings** button in the sidebar to access settings, plugin management, and updates.
 
-- **Settings** — manage authentication, allowed IPs, Discord webhooks, executor selection, and other runtime settings. Changes take effect immediately.
+- **Settings** — manage authentication, allowed IPs, Discord webhooks, executor selection, slash command appearance, the Admin Chat Sender Prefix, and toggles such as Suppress Command Output, **Suppress 'Spawned X' Confirmations**, and **Unlock Developer Commands**. Changes take effect immediately.
 - **Plugins** — install, update, and uninstall plugins from the marketplace. See [Plugins](plugins.md#marketplace) for details.
 - **Updates** — check for ggCON updates and stage them for installation on the next server restart. See [Auto-Update](auto-update.md) for details.
 
 ![Settings — Plugin Manager](assets/images/panel/panel-settings.jpg)
+
+### Admin Chat Sender Prefix
+
+Under **Settings → General**, configure how chat sent from the panel is labelled so players can tell an admin is talking. Set a display name and templates for broadcasts (default `[ADMIN] {message}`) and private whispers (default `[WHISPER from {name}] {message}`). The placeholders `{name}`, `{message}`, and `{playerName}` are filled in when the message is sent, and you can override the template per message from the Send Message dialog. Clear a template to send with no prefix. Plugin-dispatched chat and slash command responses are unaffected. See the [config reference](config-reference.md#adminchatbroadcasttemplate) for details.
+
+### Saved Teleport Destinations
+
+Under **Settings**, manage a list of named locations (e.g. "Outpost B4") with X/Y/Z coordinates and an optional yaw. Saved destinations appear in the [Teleport](#teleport-a-player) popup's dropdown for one-click teleporting.
+
+### Server Notifications
+
+Under **Settings**, an editor for SCUM's `Notifications.json` lets you manage the server's timed in-game broadcasts without editing the file by hand. The panel validates the JSON before saving. Restart the server for changes to take effect (SCUM reads this file at boot).
 
 ---
 
@@ -357,18 +373,17 @@ Each tab shows a searchable list with humanized names. Click an entity to spawn 
 
 ---
 
-## Teleport from Map
+## Teleport a player
 
-The **Teleport To...** button in the player detail popup opens the map in teleport mode:
+The **Teleport To...** button in the player detail popup opens a popup with three ways to choose a destination:
 
-1. Click **Teleport To...** on any online player
-2. The map opens with a red banner showing the target player's name and a **Cancel** button
-3. The cursor changes to a crosshair
-4. **Click anywhere on the map** to select a destination
-5. A confirmation dialog shows the target coordinates — click **OK** to teleport, or **Cancel** to pick a different spot
-6. The teleport command executes and the result appears in the Console tab
+- **Paste coordinates** — type or paste `X Y Z` (also accepts `X, Y, Z` or `X Y`). Ideal for sending a player to an exact spot
+- **Saved destination** — pick from the named locations you've configured (see [Saved Teleport Destinations](#saved-teleport-destinations))
+- **Pick on map** — opens the map in teleport mode: a red banner shows the target player's name, the cursor becomes a crosshair, and clicking the map selects the destination (confirm in the dialog). Press **Escape** or **Cancel** to exit without teleporting
 
-Press **Escape** or click **Cancel** in the banner to exit teleport mode without teleporting.
+An optional **yaw** field sets which direction the player faces on arrival (0 = North, 90 = East, 180 = South, 270 = West; leave empty to keep their current facing). The teleport result appears in the Console tab.
+
+You can also right-click anywhere on the map and choose **Teleport Player** to send any online player to that point directly.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ theme:
   features:
     - navigation.tabs
     - navigation.sections
+    - navigation.indexes
     - navigation.top
     - search.highlight
     - content.code.copy
@@ -28,6 +29,7 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - Features:
+    - features.md
     - Web Panel: web-panel.md
     - Plugins: plugins.md
     - Slash Commands: slash-commands.md
@@ -45,6 +47,7 @@ nav:
 
 markdown_extensions:
   - attr_list
+  - md_in_html
   - admonition
   - pymdownx.highlight:
       anchor_linenums: true


### PR DESCRIPTION
Catches the public docs up from **v0.12.2** (last refreshed 2026-04-04) to the current **v0.13.3** — everything customer-facing shipped in between.

## What changed

**Plugins**
- New: **NPC Tracker** and **Taxi Service** sections
- **Kill Feed** expanded: leaderboard + `/leaderboard`/`/top`, per-type Discord webhooks + PvP delay, map image, in-game chat broadcasts, multi-select filters, NPC kills
- **Quarter Master** expanded: PvP/NPC kill rewards + per-class overrides, squad-kill penalty, sales summary, export/import, delivery zones, bundle thumbnails, shop/deliveries open-close toggles + per-category enable, Grant Rations to All, GG Coins earn notifications, stack count
- **Loot Drops**: vehicles in packs, stack count

**Slash Commands**
- `/unstuck` (admin approval / cooldown / Discord options), `/leaderboard` (`/top`), `/taxi`
- Custom commands can override built-ins; `{playerName}`/`{steamId}` placeholders; new Orange color

**Web Panel**
- Identity columns (Account ID / Real IGN / Fake IGN)
- Teleport popup: paste coordinates, saved destinations, yaw
- Settings: Admin Chat Sender Prefix, Saved Teleport Destinations, Server Notifications editor, Suppress Spawned X Confirmations, Unlock Developer Commands
- Removed the dead **HUD** option from the Chat send dropdown

**HTTP API**
- `/players.json`: `profileId` / `realName` / `fakeName`
- New `GET /slash-commands.json`
- Orange message type; removed the dead `hud` method from `POST /message`
- Freshened sample version strings

**Config Reference**
- Admin chat prefix keys, `SuppressSpawnedReplies`, `UnlockDeveloperCommands`, `/unstuck` settings, Orange in color lists

**Commands**
- `#GiveItem` `StackCount` keyword syntax; Orange broadcast example

**Cleanup**
- Fixed two pre-existing broken anchors in `commands.md`

## Notes
- Supersedes #47 (HUD method removal) — please close #47 after merging.
- Verified locally with `mkdocs build` — no broken links or anchors.
- Merging to `main` auto-deploys the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)